### PR TITLE
feat: add web search hints for unmatched references

### DIFF
--- a/src/refaudit/crossref.py
+++ b/src/refaudit/crossref.py
@@ -31,6 +31,7 @@ class MatchResult:
     method: str | None = None  # 'doi', 'bibliographic', or 'doi->bibliographic'
     note: str | None = None    # reason/hint when not found
     candidates: list[dict] | None = None  # optional debug candidates
+    suggestions: list[str] | None = None  # follow-up actions for operators
 
 
 _SYNONYMS = [
@@ -207,6 +208,12 @@ class CrossrefClient:
                         candidates=None,
                     )
             cands = None
+            suggestions: list[str] = []
+            if title_guess:
+                suggestions.append(f"タイトル候補でウェブ検索: \"{title_guess}\"")
+                search_url = "https://www.google.com/search?q=" + urllib.parse.quote_plus(title_guess)
+                suggestions.append(f"Google検索: {search_url}")
+            suggestions = suggestions or None
             if self.debug:
                 # collect top 3 candidates for troubleshooting
                 cands = []
@@ -228,6 +235,7 @@ class CrossrefClient:
                 method=method,
                 note="no_match",
                 candidates=cands,
+                suggestions=suggestions,
             )
 
         # If strict (and not direct DOI), enforce title and year checks

--- a/src/refaudit/report.py
+++ b/src/refaudit/report.py
@@ -39,6 +39,13 @@ def _section_bad(r: MatchResult) -> list[str]:
                     f"  DOI: `{c.get('DOI')}`",
                 ]
             lines.append("")
+        if r.suggestions:
+            lines += [
+                "### 次のチェック候補",
+            ]
+            for hint in r.suggestions:
+                lines.append(f"- {hint}")
+            lines.append("")
         return lines
     # retracted
     lines = [


### PR DESCRIPTION
## Summary
- add storage for optional follow-up suggestions in `MatchResult`
- surface title-based web search hints when Crossref/PubMed miss
- render the hints in the Markdown report so operators know next steps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f6e518f04483338e762f7e5b1cfe3a