### PR TITLE
Add APA-style reference parsing support

### DIFF
--- a/src/refaudit/parser.py
+++ b/src/refaudit/parser.py
@@ -151,9 +151,46 @@ def is_website_reference(text: str) -> bool:
     return False
 
 
+# APA style: "Author, A. A., & Author, B. B. (2019). Title. Journal, 1(2), 3-4."
+APA_HEAD_REGEX = re.compile(
+    r"^(?P<authors>.{3,500}?)\(\s*(?P<year>(?:19|20)\d{2})[a-z]?\s*\)\s*\.\s*(?P<rest>.+)$",
+    re.DOTALL,
+)
+APA_SENTENCE_SPLIT_REGEX = re.compile(r"(?<=[.?!])\s+")
+APA_VENUE_REGEX = re.compile(r"^(?P<venue>[^,]{2,120}),\s*\d")
+
+
+def _split_apa(ref_line: str) -> dict[str, str] | None:
+    """Split an APA-style reference into author / year / title / venue parts."""
+    head = APA_HEAD_REGEX.match(ref_line or "")
+    if not head:
+        return None
+    sentences = APA_SENTENCE_SPLIT_REGEX.split(head.group("rest").strip())
+    venue_index = next(
+        (i for i, s in enumerate(sentences) if i > 0 and APA_VENUE_REGEX.match(s)),
+        1,
+    )
+    title = " ".join(sentences[:venue_index]).strip().rstrip(".").strip()
+    if len(title) < 10:
+        return None
+    venue_match = APA_VENUE_REGEX.match(sentences[venue_index]) if (
+        venue_index < len(sentences)
+    ) else None
+    venue = venue_match.group("venue").strip(" ,.:;") if venue_match else ""
+    return {
+        "authors": head.group("authors").strip(),
+        "year": head.group("year"),
+        "title": title,
+        "venue": venue,
+    }
+
+
 def extract_title_candidate(ref_line: str) -> str | None:
     if not ref_line:
         return None
+    apa = _split_apa(_normalize_reference_line(ref_line))
+    if apa:
+        return apa["title"]
     parts = [p.strip() for p in ref_line.split(".")]
     parts = [p for p in parts if p]
     if not parts:
@@ -223,8 +260,10 @@ def _author_segment(ref_line: str) -> str:
 def extract_authors(ref_line: str) -> list[str]:
     if not ref_line:
         return []
+    return _authors_from_segment(_author_segment(ref_line))
 
-    author_segment = _author_segment(ref_line)
+
+def _authors_from_segment(author_segment: str) -> list[str]:
     if not author_segment:
         return []
 
@@ -300,13 +339,16 @@ def _extract_venue(ref_line: str, title: str | None) -> str | None:
 
 def parse_reference_metadata(ref_line: str) -> ReferenceRecord:
     normalized = _normalize_reference_line(ref_line)
+    apa = _split_apa(normalized)
     title = extract_title_candidate(normalized)
     if title:
         title = re.sub(r",\s*arxiv.*$", "", title, flags=re.IGNORECASE).strip(" ,.;:")
-    authors = extract_authors(normalized)
-    year = _extract_year(normalized)
+    authors = (
+        _authors_from_segment(apa["authors"]) if apa else extract_authors(normalized)
+    )
+    year = int(apa["year"]) if apa else _extract_year(normalized)
     volume, issue, page = _extract_volume_issue_page(normalized)
-    venue = _extract_venue(normalized, title)
+    venue = (apa["venue"] if apa else None) or _extract_venue(normalized, title)
     if "arxiv" in normalized.lower() and venue == "Available from":
         venue = "arXiv"
     article_number = _extract_article_number(page)

--- a/src/refaudit/parser.py
+++ b/src/refaudit/parser.py
@@ -153,11 +153,16 @@ def is_website_reference(text: str) -> bool:
 
 # APA style: "Author, A. A., & Author, B. B. (2019). Title. Journal, 1(2), 3-4."
 APA_HEAD_REGEX = re.compile(
-    r"^(?P<authors>.{3,500}?)\(\s*(?P<year>(?:19|20)\d{2})[a-z]?\s*\)\s*\.\s*(?P<rest>.+)$",
-    re.DOTALL,
+    r"^(?P<authors>.{3,500}?)\(\s*(?P<year>(?:19|20)\d{2})[a-z]?\s*\)\s*\.\s*(?P<rest>.+)$"
 )
 APA_SENTENCE_SPLIT_REGEX = re.compile(r"(?<=[.?!])\s+")
 APA_VENUE_REGEX = re.compile(r"^(?P<venue>[^,]{2,120}),\s*\d")
+# 著者イニシャル（"E."）を除いてもピリオド区切りの文が残るなら、その (year) は著者位置ではない
+# （"…outcomes. JAMA. (2019). 321(4):345-350." のように誌名や出版社の後に来た括弧年）。
+APA_AUTHOR_INITIAL_REGEX = re.compile(r"\b[A-Z]\.")
+APA_SENTENCE_IN_AUTHORS_REGEX = re.compile(r"\.\s+\S")
+# "321(4):345-350" のような巻号ページ断片をタイトルとして採用しないための語らしさ判定。
+APA_TITLE_WORD_REGEX = re.compile(r"[A-Za-z]{3,}|[\u3040-\u30ff\u3400-\u9fff]")
 
 
 def _split_apa(ref_line: str) -> dict[str, str] | None:
@@ -165,20 +170,27 @@ def _split_apa(ref_line: str) -> dict[str, str] | None:
     head = APA_HEAD_REGEX.match(ref_line or "")
     if not head:
         return None
-    sentences = APA_SENTENCE_SPLIT_REGEX.split(head.group("rest").strip())
-    venue_index = next(
-        (i for i, s in enumerate(sentences) if i > 0 and APA_VENUE_REGEX.match(s)),
-        1,
-    )
-    title = " ".join(sentences[:venue_index]).strip().rstrip(".").strip()
-    if len(title) < 10:
+    authors = head.group("authors").strip()
+    if APA_SENTENCE_IN_AUTHORS_REGEX.search(APA_AUTHOR_INITIAL_REGEX.sub("", authors)):
         return None
-    venue_match = APA_VENUE_REGEX.match(sentences[venue_index]) if (
-        venue_index < len(sentences)
-    ) else None
+    sentences = APA_SENTENCE_SPLIT_REGEX.split(head.group("rest").strip())
+    # タイトルは原則1文目。"?"/"!" で終わる見出し（"…Who are they? The EPOS study."）のときだけ、
+    # 掲載誌らしい文に当たるまで続きを取り込む。誌名の略記（"N. Engl. J. Med."）でも
+    # 文分割は起きるため、掲載誌を前方走査してその手前を全てタイトルにするのは避ける。
+    end = 1
+    while (
+        end < len(sentences)
+        and sentences[end - 1].rstrip().endswith(("?", "!"))
+        and not APA_VENUE_REGEX.match(sentences[end])
+    ):
+        end += 1
+    title = " ".join(sentences[:end]).strip().rstrip(".").strip()
+    if len(title) < 10 or not APA_TITLE_WORD_REGEX.search(title):
+        return None
+    venue_match = APA_VENUE_REGEX.match(sentences[end]) if end < len(sentences) else None
     venue = venue_match.group("venue").strip(" ,.:;") if venue_match else ""
     return {
-        "authors": head.group("authors").strip(),
+        "authors": authors,
         "year": head.group("year"),
         "title": title,
         "venue": venue,
@@ -188,9 +200,14 @@ def _split_apa(ref_line: str) -> dict[str, str] | None:
 def extract_title_candidate(ref_line: str) -> str | None:
     if not ref_line:
         return None
-    apa = _split_apa(_normalize_reference_line(ref_line))
+    normalized = _normalize_reference_line(ref_line)
+    apa = _split_apa(normalized)
     if apa:
         return apa["title"]
+    return _title_from_segments(normalized)
+
+
+def _title_from_segments(ref_line: str) -> str | None:
     parts = [p.strip() for p in ref_line.split(".")]
     parts = [p for p in parts if p]
     if not parts:
@@ -340,7 +357,7 @@ def _extract_venue(ref_line: str, title: str | None) -> str | None:
 def parse_reference_metadata(ref_line: str) -> ReferenceRecord:
     normalized = _normalize_reference_line(ref_line)
     apa = _split_apa(normalized)
-    title = extract_title_candidate(normalized)
+    title = apa["title"] if apa else _title_from_segments(normalized)
     if title:
         title = re.sub(r",\s*arxiv.*$", "", title, flags=re.IGNORECASE).strip(" ,.;:")
     authors = (

--- a/tests/test_miscitation_detection.py
+++ b/tests/test_miscitation_detection.py
@@ -172,6 +172,49 @@ def test_parse_apa_reference_with_question_mark_title():
     assert record.issue == "11"
 
 
+def test_parse_apa_reference_keeps_subtitle_after_question_mark():
+    record = parse_reference_metadata(
+        "Veerbeek, J. M. (2011). Is accurate prediction of gait possible poststroke? "
+        "The EPOS study. Archives of Physical Medicine and Rehabilitation, 92(8), 1204-1210."
+    )
+    assert record.title == (
+        "Is accurate prediction of gait possible poststroke? The EPOS study"
+    )
+    assert record.venue == "Archives of Physical Medicine and Rehabilitation"
+
+
+def test_parenthesized_year_after_venue_is_not_treated_as_apa():
+    """"JAMA. (2019)." のような誌名後の括弧年でタイトルが巻号ページに化けない。"""
+    record = parse_reference_metadata(
+        "Smith J, Doe A. An important title about outcomes. JAMA. (2019). 321(4):345-350."
+    )
+    assert record.title == "An important title about outcomes"
+
+    record = parse_reference_metadata(
+        "Higgins JPT, Thomas J. Cochrane Handbook for Systematic Reviews. "
+        "Cochrane (2022). Version 6.3, chapter 10."
+    )
+    assert record.title == "Cochrane Handbook for Systematic Reviews"
+
+
+def test_parse_apa_reference_with_abbreviated_venue_keeps_title_clean():
+    """略記された誌名（"N. Engl. J. Med."）がタイトルに混入しない。"""
+    record = parse_reference_metadata(
+        "Smith, J. A. (2020). Deep learning for imaging. N. Engl. J. Med., 382, 1-9."
+    )
+    assert record.title == "Deep learning for imaging"
+
+
+def test_parse_apa_reference_japanese():
+    record = parse_reference_metadata(
+        "松村千佳子, 矢野義孝 (2019). 患者との医療コミュニケーションの重要性. "
+        "日本看護研究学会雑誌, 42(3), 123-130."
+    )
+    assert record.title == "患者との医療コミュニケーションの重要性"
+    assert record.venue == "日本看護研究学会雑誌"
+    assert record.year == 2019
+
+
 def test_parse_reference_metadata_extracts_core_fields():
     record = parse_reference_metadata(
         "Barteit S, Kyaw BM, Muller A, et al. The Effectiveness of Digital Game-Based Learning in Health Professions Education: Systematic Review and Meta-Analysis. JMIR Serious Games 2021; 9(3): e29080."

--- a/tests/test_miscitation_detection.py
+++ b/tests/test_miscitation_detection.py
@@ -144,6 +144,34 @@ def test_extract_authors_handles_and_and_japanese_separator():
     assert extract_authors("松村千佳子・矢野義孝. 患者との医療コミュニケーションの重要性.") == ["松村", "矢野"]
 
 
+def test_parse_apa_reference():
+    record = parse_reference_metadata(
+        "Christodoulou, E., Peek, N., & Van Calster, B. (2019). A systematic review shows "
+        "no performance benefit of machine learning over logistic regression for clinical "
+        "prediction models. Journal of Clinical Epidemiology, 110, 12-22."
+    )
+    assert record.title == (
+        "A systematic review shows no performance benefit of machine learning over "
+        "logistic regression for clinical prediction models"
+    )
+    assert record.authors == ["christodoulou", "peek", "van"]
+    assert record.year == 2019
+    assert record.venue == "Journal of Clinical Epidemiology"
+    assert record.volume == "110"
+    assert record.page == "12-22"
+
+
+def test_parse_apa_reference_with_question_mark_title():
+    record = parse_reference_metadata(
+        "Mulder, M., & van Wegen, E. E. H. (2019). Prospectively classifying community "
+        "walkers after stroke: Who are they? Archives of Physical Medicine and "
+        "Rehabilitation, 100(11), 2113-2118."
+    )
+    assert record.title == "Prospectively classifying community walkers after stroke: Who are they?"
+    assert record.venue == "Archives of Physical Medicine and Rehabilitation"
+    assert record.issue == "11"
+
+
 def test_parse_reference_metadata_extracts_core_fields():
     record = parse_reference_metadata(
         "Barteit S, Kyaw BM, Muller A, et al. The Effectiveness of Digital Game-Based Learning in Health Professions Education: Systematic Review and Meta-Analysis. JMIR Serious Games 2021; 9(3): e29080."


### PR DESCRIPTION
## Summary
Adds comprehensive support for parsing APA-style bibliographic references, enabling more accurate extraction of titles, authors, years, and venues from academic citations in APA format.

## Key Changes
- **New APA parser module**: Implemented `_split_apa()` function with regex patterns to identify and parse APA-style references with the format "Author(s) (Year). Title. Venue, Volume(Issue), Pages."
- **Intelligent title extraction**: Handles edge cases including:
  - Titles ending with question marks or exclamation marks followed by subtitles
  - Abbreviated venue names (e.g., "N. Engl. J. Med.") that don't interfere with title extraction
  - Parenthesized years after venue names (non-APA patterns) that should not be treated as APA format
- **Refactored author extraction**: Extracted `_authors_from_segment()` helper function to support both APA and non-APA parsing paths
- **Enhanced metadata parsing**: Updated `parse_reference_metadata()` to prioritize APA parsing when applicable, falling back to existing segment-based parsing for non-APA formats
- **Comprehensive test coverage**: Added 7 new test cases covering:
  - Standard APA references
  - References with question marks in titles
  - Subtitles after question marks
  - Non-APA parenthesized years
  - Abbreviated venue names
  - Japanese-language APA references

## Implementation Details
- Uses regex patterns to validate APA structure before attempting full parsing
- Validates author segments to avoid false positives (e.g., distinguishing author initials from sentence-ending periods)
- Implements heuristic title validation (minimum length, presence of meaningful words) to reject malformed extractions
- Supports both English and Japanese language references

https://claude.ai/code/session_016yFXHGW6oudN4FSHhY3bMv